### PR TITLE
to make it run on openshift disable mlock, IPC_LOCK and FsGroup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ REGISTRY ?= kubevault
 git_branch       := $(shell git rev-parse --abbrev-ref HEAD)
 git_tag          := $(shell git describe --exact-match --abbrev=0 2>/dev/null || echo "")
 commit_hash      := $(shell git rev-parse --verify HEAD)
-commit_timestamp := $(shell date --date="@$$(git show -s --format=%ct)" --utc +%FT%T)
+commit_timestamp := 1590473912#$(shell date --date="@$$(git show -s --format=%ct)" --utc +%FT%T)
 
 VERSION          := $(shell git describe --tags --always --dirty)
 version_strategy := commit_hash

--- a/pkg/controller/vault.go
+++ b/pkg/controller/vault.go
@@ -484,7 +484,8 @@ func (v *vaultSrv) GetPodTemplate(c core.Container, saName string) *core.PodTemp
 	if v.vs.Spec.PodTemplate.Spec.SecurityContext == nil {
 		v.vs.Spec.PodTemplate.Spec.SecurityContext = &core.PodSecurityContext{}
 	}
-	v.vs.Spec.PodTemplate.Spec.SecurityContext.FSGroup = &defaultFsGroup
+	//Disabled because FsGroup must be automatically set by OpenShift
+	//v.vs.Spec.PodTemplate.Spec.SecurityContext.FSGroup = &defaultFsGroup
 
 	return &core.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
@@ -529,13 +530,14 @@ func (v *vaultSrv) GetContainer() core.Container {
 				Value: util.VaultServiceURL(v.vs.Name, v.vs.Namespace, VaultClusterPort),
 			},
 		},
-		SecurityContext: &core.SecurityContext{
-			Capabilities: &core.Capabilities{
-				// Vault requires mlock syscall to work.
-				// Without this it would fail "Error initializing core: Failed to lock memory: cannot allocate memory"
-				Add: []core.Capability{"IPC_LOCK"},
-			},
-		},
+		//Disabled because IPC_LOCK on OpenShift not working
+		//SecurityContext: &core.SecurityContext{
+		//	Capabilities: &core.Capabilities{
+		//		// Vault requires mlock syscall to work.
+		//		// Without this it would fail "Error initializing core: Failed to lock memory: cannot allocate memory"
+		//		Add: []core.Capability{"IPC_LOCK"},
+		//	},
+		//},
 		Ports: []core.ContainerPort{{
 			Name:          "vault-port",
 			ContainerPort: int32(VaultClientPort),

--- a/pkg/vault/util/vault_config.go
+++ b/pkg/vault/util/vault_config.go
@@ -39,7 +39,11 @@ const (
 	VaultTLSAssetDir = "/etc/vault/tls/"
 )
 
+//To run on Openshift mlock must be disabled
 var listenerFmt = `
+disable_mlock = true
+ui = true
+
 listener "tcp" {
   address = "0.0.0.0:8200"
   cluster_address = "0.0.0.0:8201"


### PR DESCRIPTION
- timestamp hack only because of issues on macbook

- remove 'fsGroup' (filesystem group id) parameter in Deployment
   - This has to be done because OpenShift allocates a random ID as fsGroup, therefore no predefined ID can be set.
       'fsGroup' can be enabled with a custom SCC (security context constraints), we decided not to use it.

- remove 'IPC_LOCK' (mlock syscall which blocks process memory from being swapped to disk) parameter in Deployment
   - IPC_LOCK is usually need in Vault to avoid swapping. Anyhow, this option would also require a custom scc (security 
      context constraint). OpenShift as per default doesn't allow swapping so removing this option isn't problematic for us. 
      Discussed: https://github.com/coreos/vault-operator/issues/311

- set 'disable_mlock' in ConfigMap
   - To configure vault not to try to lock the memory in first place (described above) you need to set this option.

- set 'ui = true' in ConfigMap
   - To use the Vault Web Gui you need to enable this option.
